### PR TITLE
feat: review soft delete

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -79,6 +79,7 @@ CREATE TABLE likes
     id         UUID PRIMARY KEY,
     user_id    UUID NOT NULL,
     review_id  UUID NOT NULL,
+    is_deleted BOOLEAN             NOT NULL DEFAULT FALSE,
     created_at TIMESTAMP DEFAULT CURRENT_DATE,
     CONSTRAINT unique_review_like UNIQUE (user_id, review_id)
 );

--- a/schema.sql
+++ b/schema.sql
@@ -80,7 +80,8 @@ CREATE TABLE likes
     user_id    UUID NOT NULL,
     review_id  UUID NOT NULL,
     is_deleted BOOLEAN             NOT NULL DEFAULT FALSE,
-    created_at TIMESTAMP DEFAULT CURRENT_DATE,
+    created_at TIMESTAMP     NOT NULL,
+    updated_at TIMESTAMP,
     CONSTRAINT unique_review_like UNIQUE (user_id, review_id)
 );
 

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/controller/ReviewController.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/controller/ReviewController.java
@@ -56,6 +56,7 @@ public class ReviewController {
     public ResponseEntity<Void> softDelete(
             @PathVariable UUID reviewId,
             @RequestHeader("Deokhugam-Request-User-ID") UUID userId) {
+        log.info("리뷰 논리 삭제 요청: {}", reviewId);
         reviewService.softDelete(userId, reviewId);
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/controller/ReviewController.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/controller/ReviewController.java
@@ -45,10 +45,20 @@ public class ReviewController {
     public ResponseEntity<ReviewDto> update(
             @PathVariable UUID reviewId,
             @RequestHeader("Deokhugam-Request-User-ID") UUID userId,
-            @RequestBody @Valid ReviewUpdateRequest request){
+            @RequestBody @Valid ReviewUpdateRequest request) {
         log.info("리뷰 수정 요청: {}", reviewId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(reviewService.update(userId, reviewId, request));
+    }
+
+    @DeleteMapping("{reviewId}")
+    public ResponseEntity<Void> softDelete(
+            @PathVariable UUID reviewId,
+            @RequestHeader("Deokhugam-Request-User-ID") UUID userId) {
+        reviewService.softDelete(userId, reviewId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .build();
     }
 }

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/entity/Like.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/entity/Like.java
@@ -2,6 +2,7 @@ package com.part3.team07.sb01deokhugamteam07.entity;
 
 
 import com.part3.team07.sb01deokhugamteam07.entity.base.BaseEntity;
+import com.part3.team07.sb01deokhugamteam07.entity.base.BaseSoftDeletableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import java.util.UUID;
@@ -18,7 +19,7 @@ import jakarta.persistence.Table;
 @AllArgsConstructor
 @Table(name ="likes")
 @Entity
-public class Like extends BaseEntity {
+public class Like extends BaseSoftDeletableEntity {
 
   @Column(nullable = false)
   private UUID userId;

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/entity/Review.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/entity/Review.java
@@ -55,4 +55,8 @@ public class Review extends BaseSoftDeletableEntity {
     this.rating = rating;
   }
 
+  public void softDelete(){
+    delete();
+  }
+
 }

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/repository/ReviewRepository.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/repository/ReviewRepository.java
@@ -5,6 +5,8 @@ import com.part3.team07.sb01deokhugamteam07.entity.Review;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+
+import com.part3.team07.sb01deokhugamteam07.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
@@ -15,7 +17,9 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
       LocalDateTime endDateTime
   );
 
-    boolean existsByUserIdAndBookId(UUID userId, UUID bookId);
+  boolean existsByUserIdAndBookId(UUID userId, UUID bookId);
 
-    List<Review> findAllByBook(Book book);
+  List<Review> findAllByBook(Book book);
+
+  List<Review> findAllByUser(User user);
 }

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/repository/ReviewRepository.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.part3.team07.sb01deokhugamteam07.repository;
 
+import com.part3.team07.sb01deokhugamteam07.entity.Book;
 import com.part3.team07.sb01deokhugamteam07.entity.Review;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,4 +16,6 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
   );
 
     boolean existsByUserIdAndBookId(UUID userId, UUID bookId);
+
+    List<Review> findAllByBook(Book book);
 }

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/service/ReviewService.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/service/ReviewService.java
@@ -68,10 +68,24 @@ public class ReviewService {
                 .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
 
         if(!review.isReviewer(userId)){
-            throw new IllegalArgumentException("본인이 작성한 리뷰가 아닙니다.");
+            throw new IllegalArgumentException("본인이 작성한 리뷰가 아닙니다."); //403 - 리뷰 수정 권한 없음
         }
         review.update(request.content(), request.rating());
         log.info("리뷰 수정 완료: id={}", reviewId);
         return ReviewMapper.toDto(review);
+    }
+
+    @Transactional
+    public void softDelete(UUID userId, UUID reviewId){
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+
+        if(!review.isReviewer(userId)){
+            throw new IllegalArgumentException("본인이 작성한 리뷰가 아닙니다."); //403 - 리뷰 삭제 권한 없음
+        }
+
+        // TODO 댓글 논리 삭제 로직 추가
+
+        review.softDelete();
     }
 }

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/service/ReviewService.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/service/ReviewService.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -85,7 +86,16 @@ public class ReviewService {
         }
 
         // TODO 댓글 논리 삭제 로직 추가
-
         review.softDelete();
     }
+
+    @Transactional
+    public void softDeleteAllByBook(Book book) {
+        List<Review> reviews = reviewRepository.findAllByBook(book);
+        reviews.forEach(review -> {
+            review.softDelete();
+            // TODO 댓글 논리 삭제 로직 추가
+        });
+    }
+
 }

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/service/ReviewService.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/service/ReviewService.java
@@ -100,7 +100,18 @@ public class ReviewService {
             review.softDelete();
             // TODO 댓글 논리 삭제 로직 추가
         });
-        log.info("모든 리뷰 논리 삭제 완료. bookId={}", book.getId());
+        log.info("book 이 가진 모든 리뷰 논리 삭제 완료. bookId={}", book.getId());
     }
 
+    @Transactional
+    public void softDeleteAllByUser(User user) {
+        List<Review> reviews = reviewRepository.findAllByUser(user);
+        log.info("{}개의 리뷰를 논리 삭제 시작. userId={}", reviews.size(), user.getId());
+        reviews.forEach(review -> {
+            review.softDelete();
+            // TODO 댓글 논리 삭제 로직 추가
+        });
+        log.info("사용자가 작성한 모든 리뷰 논리 삭제 완료. userId={}", user.getId());
+    }
+    
 }

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/service/ReviewService.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/service/ReviewService.java
@@ -78,6 +78,7 @@ public class ReviewService {
 
     @Transactional
     public void softDelete(UUID userId, UUID reviewId){
+        log.debug("리뷰 논리 삭제 시작: id={}", reviewId);
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
 
@@ -86,16 +87,20 @@ public class ReviewService {
         }
 
         // TODO 댓글 논리 삭제 로직 추가
+
+        log.info("리뷰 논리 삭제 완료: id={}", reviewId);
         review.softDelete();
     }
 
     @Transactional
     public void softDeleteAllByBook(Book book) {
         List<Review> reviews = reviewRepository.findAllByBook(book);
+        log.info("{}개의 리뷰를 논리 삭제 시작. bookId={}", reviews.size(), book.getId());
         reviews.forEach(review -> {
             review.softDelete();
             // TODO 댓글 논리 삭제 로직 추가
         });
+        log.info("모든 리뷰 논리 삭제 완료. bookId={}", book.getId());
     }
 
 }

--- a/src/test/java/com/part3/team07/sb01deokhugamteam07/controller/ReviewControllerTest.java
+++ b/src/test/java/com/part3/team07/sb01deokhugamteam07/controller/ReviewControllerTest.java
@@ -1,6 +1,5 @@
 package com.part3.team07.sb01deokhugamteam07.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.part3.team07.sb01deokhugamteam07.dto.review.ReviewDto;
 import com.part3.team07.sb01deokhugamteam07.dto.review.request.ReviewCreateRequest;
@@ -21,6 +20,8 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -230,4 +231,23 @@ class ReviewControllerTest {
                 .with(csrf()))
                 .andExpect(status().isBadRequest());
     }*/
+
+    @DisplayName("리뷰를 논리 삭제할 수 있다.")
+    @Test
+    void softDelete() throws Exception {
+        //given
+        UUID userId = UUID.randomUUID();
+        UUID reviewId = UUID.randomUUID();
+
+        //when
+        willDoNothing().given(reviewService).softDelete(userId, reviewId);
+
+        //then
+        mockMvc.perform(delete("/api/reviews/{reviewId}", reviewId)
+                .header("Deokhugam-Request-User-ID", userId.toString())
+                .with(csrf()))
+                    .andExpect(status().isOk());
+        verify(reviewService).softDelete(userId, reviewId);
+    }
+
 }

--- a/src/test/java/com/part3/team07/sb01deokhugamteam07/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/part3/team07/sb01deokhugamteam07/integration/ReviewIntegrationTest.java
@@ -195,4 +195,44 @@ public class ReviewIntegrationTest {
                 .andExpect(jsonPath("$.content").value(request.content()))
                 .andExpect(jsonPath("$.rating").value(request.rating()));
     }
+
+    @DisplayName("리뷰 논리 삭제 api 통합 테스트")
+    @Test
+    void test() throws Exception {
+        //given
+        User user = User.builder()
+                .nickname("user")
+                .email("user@abc.com")
+                .password("user1234")
+                .build();
+        userRepository.save(user);
+
+        Book book = Book.builder()
+                .title("Book")
+                .author("Author")
+                .description("Description")
+                .publisher("Publisher")
+                .publishDate(LocalDate.now())
+                .isbn("1234567890123")
+                .thumbnailFileName("Url")
+                .reviewCount(0)
+                .rating(0.0)
+                .build();
+        bookRepository.save(book);
+
+        Review review = Review.builder()
+                .user(user)
+                .book(book)
+                .content("정말 좋은 책입니다.")
+                .rating(5)
+                .likeCount(0)
+                .commentCount(0)
+                .build();
+        reviewRepository.save(review);
+
+        //when then
+        mockMvc.perform(delete("/api/reviews/{reviewId}", review.getId())
+                .header("Deokhugam-Request-User-ID", user.getId().toString()))
+                .andExpect(status().isOk());
+    }
 }

--- a/src/test/java/com/part3/team07/sb01deokhugamteam07/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/part3/team07/sb01deokhugamteam07/repository/ReviewRepositoryTest.java
@@ -91,6 +91,26 @@ class ReviewRepositoryTest {
                 .containsExactlyInAnyOrder("닉네임1", "닉네임2");
     }
 
+    @DisplayName("유저가 작성한 모든 리뷰를 조회할 수 있다.")
+    @Test
+    void findAllByUser() {
+        //given
+        User user = userRepository.save(createTestUser("닉네임", "user1@abc.com"));
+        Book book1 = bookRepository.save(createTestBook("book1"));
+        Book book2 = bookRepository.save(createTestBook("book2"));
+        reviewRepository.save(createTestReview(user, book1));
+        reviewRepository.save(createTestReview(user, book2));
+
+        //when
+        List<Review> reviews = reviewRepository.findAllByUser(user);
+
+        //then
+        assertThat(reviews).hasSize(2);
+        assertThat(reviews)
+                .extracting("book.title")
+                .containsExactlyInAnyOrder("book1", "book2");
+    }
+
 
     private User createTestUser(String nickname, String email) {
         return User.builder()

--- a/src/test/java/com/part3/team07/sb01deokhugamteam07/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/part3/team07/sb01deokhugamteam07/repository/ReviewRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,6 +69,26 @@ class ReviewRepositoryTest {
 
         // then
         assertThat(exists).isFalse();
+    }
+
+    @DisplayName("해당 책에 있는 모든 리뷰를 조회할 수 있다.")
+    @Test
+    void findAllByBook() {
+        //given
+        User user1 = userRepository.save(createTestUser("닉네임1", "user1@abc.com"));
+        User user2 = userRepository.save(createTestUser("닉네임2", "user2@abc.com"));
+        Book book = bookRepository.save(createTestBook("book"));
+        reviewRepository.save(createTestReview(user1, book));
+        reviewRepository.save(createTestReview(user2, book));
+
+        //when
+        List<Review> reviews = reviewRepository.findAllByBook(book);
+
+        //then
+        assertThat(reviews).hasSize(2);
+        assertThat(reviews)
+                .extracting("user.nickname")
+                .containsExactlyInAnyOrder("닉네임1", "닉네임2");
     }
 
 

--- a/src/test/java/com/part3/team07/sb01deokhugamteam07/service/ReviewServiceTest.java
+++ b/src/test/java/com/part3/team07/sb01deokhugamteam07/service/ReviewServiceTest.java
@@ -252,4 +252,16 @@ class ReviewServiceTest {
         //then
         assertThat(review.isDeleted()).isTrue();
     }
+
+    @DisplayName("존재하지 않은 리뷰는 논리 삭제할 수 없다.")
+    @Test
+    void softDelete_fail_whenUserIsNotAuthor() {
+        //given
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+        //when then
+        assertThatThrownBy(() -> reviewService.softDelete(userId, reviewId))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
 }

--- a/src/test/java/com/part3/team07/sb01deokhugamteam07/service/ReviewServiceTest.java
+++ b/src/test/java/com/part3/team07/sb01deokhugamteam07/service/ReviewServiceTest.java
@@ -307,4 +307,34 @@ class ReviewServiceTest {
         assertThat(review2.isDeleted()).isTrue();
     }
 
+    @DisplayName("user 기준으로 모든 리뷰를 논리 삭제한다.")
+    @Test
+    void softDeleteAllByUser() {
+        // given
+        Review review1 = Review.builder()
+                .user(user)
+                .book(book)
+                .content("리뷰1")
+                .rating(4)
+                .likeCount(0)
+                .commentCount(0)
+                .build();
+        Review review2 = Review.builder()
+                .user(user)
+                .book(book)
+                .content("리뷰2")
+                .rating(5)
+                .likeCount(0)
+                .commentCount(0)
+                .build();
+        given(reviewRepository.findAllByUser(user)).willReturn(List.of(review1, review2));
+
+        // when
+        reviewService.softDeleteAllByUser(user);
+
+        // then
+        assertThat(review1.isDeleted()).isTrue();
+        assertThat(review2.isDeleted()).isTrue();
+    }
+
 }

--- a/src/test/java/com/part3/team07/sb01deokhugamteam07/service/ReviewServiceTest.java
+++ b/src/test/java/com/part3/team07/sb01deokhugamteam07/service/ReviewServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -275,4 +276,35 @@ class ReviewServiceTest {
         assertThatThrownBy(() -> reviewService.softDelete(otherUserId, reviewId))
                 .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @DisplayName("book 기준으로 모든 리뷰를 논리 삭제한다.")
+    @Test
+    void softDeleteAllByBook() {
+        // given
+        Review review1 = Review.builder()
+                .user(user)
+                .book(book)
+                .content("리뷰1")
+                .rating(4)
+                .likeCount(0)
+                .commentCount(0)
+                .build();
+        Review review2 = Review.builder()
+                .user(user)
+                .book(book)
+                .content("리뷰2")
+                .rating(5)
+                .likeCount(0)
+                .commentCount(0)
+                .build();
+        given(reviewRepository.findAllByBook(book)).willReturn(List.of(review1, review2));
+
+        // when
+        reviewService.softDeleteAllByBook(book);
+
+        // then
+        assertThat(review1.isDeleted()).isTrue();
+        assertThat(review2.isDeleted()).isTrue();
+    }
+
 }

--- a/src/test/java/com/part3/team07/sb01deokhugamteam07/service/ReviewServiceTest.java
+++ b/src/test/java/com/part3/team07/sb01deokhugamteam07/service/ReviewServiceTest.java
@@ -239,4 +239,17 @@ class ReviewServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("리뷰를 찾을 수 없습니다.");
     }
+
+    @DisplayName("리뷰 논리 삭제를 할 수 있다.")
+    @Test
+    void softDelete() {
+        //given
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+        //when
+        reviewService.softDelete(userId, reviewId);
+
+        //then
+        assertThat(review.isDeleted()).isTrue();
+    }
 }

--- a/src/test/java/com/part3/team07/sb01deokhugamteam07/service/ReviewServiceTest.java
+++ b/src/test/java/com/part3/team07/sb01deokhugamteam07/service/ReviewServiceTest.java
@@ -264,4 +264,15 @@ class ReviewServiceTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @DisplayName("본인이 작성하지 않은 리뷰는 논리 삭제할 수 없다.")
+    @Test
+    void softDelete_fail_whenReviewNotFound() {
+        //given
+        UUID otherUserId = UUID.randomUUID();
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+        //when then
+        assertThatThrownBy(() -> reviewService.softDelete(otherUserId, reviewId))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 }


### PR DESCRIPTION
<!--- PR 제목: 브랜치 이름 -->

## #️⃣ Issue Number

#54

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

리뷰 논리 삭제 기능 구현
도서 기준 논리 삭제를 위한 softDeleteAllByBook() 메서드 구현
사용자 기준 리뷰 삭제를 위한 softDeleteAllByUser() 메서드 구현

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 리뷰 논리 삭제 시, 좋아요와 댓글도 함께 논리 삭제되는 부분은 추후 추가 예정입니다.

- 리뷰 논리 삭제는 아래 메서드를 통해 수행할 수 있습니다:
사용자 기준: ReviewService.softDeleteAllByUser(User user)
도서 기준: ReviewService.softDeleteAllByBook(Book book)