### PR TITLE
fix: dashboard bug fix

### DIFF
--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/dto/book/PopularBookDto.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/dto/book/PopularBookDto.java
@@ -10,7 +10,7 @@ public record PopularBookDto(
     UUID bookId,
     String title,
     String author,
-    String thumbnailFileName,
+    String thumbnailUrl,
     Period period,
     int rank,
     BigDecimal score,

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/repository/DashboardRepository.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/repository/DashboardRepository.java
@@ -20,9 +20,9 @@ public interface DashboardRepository extends JpaRepository<Dashboard, UUID> {
       "FROM dashboards " +
       "WHERE key_type = 'USER' " +
       "AND value_type IN ('REVIEW_SCORE_SUM', 'LIKE_COUNT', 'COMMENT_COUNT') " +
-      "AND period = CAST(:period AS VARCHAR) " +
+      "AND period = :period " +
       "GROUP BY \"key\"", nativeQuery = true)
-  List<UserMetricsDTO> getUserMetrics(@Param("period") Period period);
+  List<UserMetricsDTO> getUserMetrics(@Param("period") String period);
 
   long countByKeyTypeAndPeriod(KeyType keyType, Period period);
 

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/repository/DashboardRepository.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/repository/DashboardRepository.java
@@ -4,6 +4,7 @@ import com.part3.team07.sb01deokhugamteam07.dto.user.UserMetricsDTO;
 import com.part3.team07.sb01deokhugamteam07.entity.Dashboard;
 import com.part3.team07.sb01deokhugamteam07.entity.KeyType;
 import com.part3.team07.sb01deokhugamteam07.entity.Period;
+import com.part3.team07.sb01deokhugamteam07.entity.ValueType;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,5 +26,6 @@ public interface DashboardRepository extends JpaRepository<Dashboard, UUID> {
   List<UserMetricsDTO> getUserMetrics(@Param("period") String period);
 
   long countByKeyTypeAndPeriod(KeyType keyType, Period period);
+  long countByKeyTypeAndPeriodAndValueType(KeyType keyType, Period period, ValueType valueType);
 
 }

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/scheduler/ApplicationScheduler.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/scheduler/ApplicationScheduler.java
@@ -4,6 +4,7 @@ import com.part3.team07.sb01deokhugamteam07.batch.popularbook.PopularBookDashboa
 import com.part3.team07.sb01deokhugamteam07.batch.popularreview.PopularReviewDashboardBatchService;
 import com.part3.team07.sb01deokhugamteam07.batch.poweruser.PowerUserDashboardBatchService;
 import com.part3.team07.sb01deokhugamteam07.entity.Period;
+import com.part3.team07.sb01deokhugamteam07.service.DashboardService;
 import com.part3.team07.sb01deokhugamteam07.service.NotificationService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +19,21 @@ public class ApplicationScheduler {
   private final PopularBookDashboardBatchService popularBookDashboardBatchService;
   private final PopularReviewDashboardBatchService popularReviewDashboardBatchService;
   private final NotificationService notificationService;
+  private final DashboardService dashboardService;
 
-  @Scheduled(cron = "0 25 17 * * *")
+
+  @Scheduled(cron = "0 13 19 * * *")
+  public void deleteDashboard(){
+    log.info("오전 3시 : 대시보드 일괄 삭제 시작");
+    try {
+      dashboardService.delete();
+    }catch (Exception e){
+      log.warn("대시보드 일괄 삭제 중 오류 발생: {}", e.getMessage(), e);
+    }
+  }
+
+
+  @Scheduled(cron = "0 14 19 * * *")
   public void calculateAllDashboardData(){
     log.info("오전 3시 : 대시보드 데이터 일괄 계산 시작");
     // 순차 실행

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/scheduler/ApplicationScheduler.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/scheduler/ApplicationScheduler.java
@@ -22,7 +22,7 @@ public class ApplicationScheduler {
   private final DashboardService dashboardService;
 
 
-  @Scheduled(cron = "0 13 19 * * *")
+  @Scheduled(cron = "0 0 15 * * *")
   public void deleteDashboard(){
     log.info("오전 3시 : 대시보드 일괄 삭제 시작");
     try {
@@ -33,7 +33,7 @@ public class ApplicationScheduler {
   }
 
 
-  @Scheduled(cron = "0 14 19 * * *")
+  @Scheduled(cron = "0 1 15 * * *")
   public void calculateAllDashboardData(){
     log.info("오전 3시 : 대시보드 데이터 일괄 계산 시작");
     // 순차 실행

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/service/DashboardService.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/service/DashboardService.java
@@ -165,7 +165,7 @@ public class DashboardService {
         content,
         nextCursor,
         nextAfter,
-        content.size(),
+        limit,
         totalElement,
         hasNext
     );
@@ -272,7 +272,7 @@ public class DashboardService {
         content,
         nextCursor,
         nextAfter,
-        content.size(),
+        limit,
         totalElement,
         hasNext
     );
@@ -380,7 +380,7 @@ public class DashboardService {
         content,
         nextCursor,
         nextAfter,
-        content.size(),
+        limit,
         totalElement,
         hasNext
     );

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/service/DashboardService.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/service/DashboardService.java
@@ -111,7 +111,8 @@ public class DashboardService {
         .collect(Collectors.toMap(User::getId, user -> user));
 
     // 5. 사용자별 추가 지표 정보 (리뷰점수합, 좋아요수, 댓글수) 조회
-    List<UserMetricsDTO> userMetrics = dashboardRepository.getUserMetrics(period);
+    List<UserMetricsDTO> userMetrics = dashboardRepository.getUserMetrics(period.name());
+
     Map<UUID, UserMetricsDTO> metricsDTOMap = userMetrics.stream()
         .collect(Collectors.toMap(UserMetricsDTO::userId, Function.identity()));
 
@@ -120,8 +121,10 @@ public class DashboardService {
     for (Dashboard d : dashboards) {
       UUID userId = d.getKey();
       User user = userMap.get(userId);
+
       // 유저 지표 정보
       UserMetricsDTO metrics = metricsDTOMap.get(userId);
+
       BigDecimal reviewScoreSum =
           metrics != null && metrics.reviewScoreSum() != null ? metrics.reviewScoreSum() : BigDecimal.ZERO;
       int likeCount =
@@ -152,7 +155,7 @@ public class DashboardService {
     LocalDateTime nextAfter = hasNext ? dashboards.get(dashboards.size() - 1).getCreatedAt() : null;
 
     // 8. 전체 User 수 (기간 + USER 키타입 조건)
-    long totalElement = dashboardRepository.countByKeyTypeAndPeriod(KeyType.USER, period);
+    long totalElement = dashboardRepository.countByKeyTypeAndPeriod(KeyType.USER, period); // TODO 단일 key 를 통해 계산. 이 두 가지 조건만 거니까 모든 record 의 합이 나온다.
 
     log.info("Power User 조회 완료: 총 {}명 중 {}명 반환, 다음 페이지: {}",
         totalElement, content.size(), hasNext);

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/service/DashboardService.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/service/DashboardService.java
@@ -14,6 +14,7 @@ import com.part3.team07.sb01deokhugamteam07.entity.KeyType;
 import com.part3.team07.sb01deokhugamteam07.entity.Period;
 import com.part3.team07.sb01deokhugamteam07.entity.Review;
 import com.part3.team07.sb01deokhugamteam07.entity.User;
+import com.part3.team07.sb01deokhugamteam07.entity.ValueType;
 import com.part3.team07.sb01deokhugamteam07.exception.book.BookNotFoundException;
 import com.part3.team07.sb01deokhugamteam07.repository.BookRepository;
 import com.part3.team07.sb01deokhugamteam07.repository.DashboardRepository;
@@ -155,7 +156,7 @@ public class DashboardService {
     LocalDateTime nextAfter = hasNext ? dashboards.get(dashboards.size() - 1).getCreatedAt() : null;
 
     // 8. 전체 User 수 (기간 + USER 키타입 조건)
-    long totalElement = dashboardRepository.countByKeyTypeAndPeriod(KeyType.USER, period); // TODO 단일 key 를 통해 계산. 이 두 가지 조건만 거니까 모든 record 의 합이 나온다.
+    long totalElement = dashboardRepository.countByKeyTypeAndPeriodAndValueType(KeyType.USER, period, ValueType.SCORE);
 
     log.info("Power User 조회 완료: 총 {}명 중 {}명 반환, 다음 페이지: {}",
         totalElement, content.size(), hasNext);

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/service/DashboardService.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/service/DashboardService.java
@@ -366,7 +366,7 @@ public class DashboardService {
 
     // 6. 다음 페이지 커서 및 after 값 설정
     String nextCursor =
-        hasNext ? String.valueOf(dashboards.get(dashboards.get(dashboards.size() - 1).getRank()))
+        hasNext ? String.valueOf(dashboards.get(dashboards.size() - 1).getRank())
             : null;
     LocalDateTime nextAfter = hasNext ? dashboards.get(dashboards.size() - 1).getCreatedAt() : null;
 

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/service/DashboardService.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/service/DashboardService.java
@@ -43,6 +43,15 @@ public class DashboardService {
   private final ReviewRepository reviewRepository;
   private final BookRepository bookRepository;
 
+
+  /**
+   * 대시보드 삭제 기능
+   * **/
+  public void delete(){
+    dashboardRepository.deleteAll();
+  }
+
+
   /**
    * Power User 조회합니다.
    *

--- a/src/test/java/com/part3/team07/sb01deokhugamteam07/service/DashboardServiceTest.java
+++ b/src/test/java/com/part3/team07/sb01deokhugamteam07/service/DashboardServiceTest.java
@@ -119,7 +119,7 @@ class DashboardServiceTest {
         eq(period), eq("ASC"), eq(null), eq(null), eq(limit + 1), eq(KeyType.USER))
     ).thenReturn(mockDashboards);
 
-    when(dashboardRepository.getUserMetrics(eq(period))).thenReturn(mockUserMetrics);
+    when(dashboardRepository.getUserMetrics(eq(period.name()))).thenReturn(mockUserMetrics);
 
     when(dashboardRepository.countByKeyTypeAndPeriod(eq(KeyType.USER),
         eq(Period.WEEKLY))).thenReturn(1L);

--- a/src/test/java/com/part3/team07/sb01deokhugamteam07/service/DashboardServiceTest.java
+++ b/src/test/java/com/part3/team07/sb01deokhugamteam07/service/DashboardServiceTest.java
@@ -121,8 +121,8 @@ class DashboardServiceTest {
 
     when(dashboardRepository.getUserMetrics(eq(period.name()))).thenReturn(mockUserMetrics);
 
-    when(dashboardRepository.countByKeyTypeAndPeriod(eq(KeyType.USER),
-        eq(Period.WEEKLY))).thenReturn(1L);
+    when(dashboardRepository.countByKeyTypeAndPeriodAndValueType(eq(KeyType.USER),
+        eq(Period.WEEKLY), eq(ValueType.SCORE))).thenReturn(1L);
 
     // when
     CursorPageResponsePowerUserDto result = dashboardService.getPowerUsers(


### PR DESCRIPTION
## #️⃣ Issue Number
[#173](https://github.com/SB01-Team07/sb01-deokhugam-team07/issues/173)

## 📝 요약(Summary)
대시보드 연산 기능 오류 수정
- native query 에서 Enum 파라미터 String 으로 명시적 변환
- 중복된 get() 호출 제거
- 파워 유저의 totalElement 조건에 valueType 을 추가하여 실제 유저 수만 측정
- CursorPageResponse{*}Dto 의 size 필드를 content.size() -> limit 으로 변경

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

<데이터>
**- User 계정 : 1stUser~10stUser, example** 

![image](https://github.com/user-attachments/assets/af388261-7ac3-4ce6-a55e-8a5acc16a5b7)
![image](https://github.com/user-attachments/assets/08680213-b7e9-4b9b-9bfa-fcb4c129fb25)
**- Book이 정렬된대로 리뷰 생성**
(*Spring Security 3.1 도서는 페이지네이션 확인을 위해 추가)
책에 주는 별점 5 4 4 4 3 3 3 2 2 1
**- 이전에 생성했던 모든 리뷰에 좋아요/댓글 작성**
(e.g. 1stUser 의 리뷰 ← 2stUser 좋아요/댓글, 1stUser, 2stUser 의 리뷰← 3stUser 좋아요/ 댓글 . . . 10stUser 까지 반복)
**- 자신의 게시글에 댓글 달기**
(e.g. 1stUser가 1stUser 의 리뷰에 댓글 10개 달기  . . . 10stUser가 10stUser 의 리뷰에 댓글 1개 달기)


### 파워 유저
<img width="770" alt="image" src="https://github.com/user-attachments/assets/04653135-91c7-440f-a4d5-20fb60f30326" />

![image](https://github.com/user-attachments/assets/92aa603f-f1d1-4d7a-837a-64d2c483e52a)

유저 페이지네이션이 안 되는 건 프로토 페이지 또한 동일합니다.



### 인기 도서
![image](https://github.com/user-attachments/assets/a7377874-f557-4fee-aa85-517cfc96e2de)
![image](https://github.com/user-attachments/assets/6357eb5c-6a5b-4812-bf48-ce6c45c07d1b)
동일 점수 동일 Rank 처리

![image](https://github.com/user-attachments/assets/d75428d5-9584-4dd3-949a-a28938555a89)
페이지네이션 확인 완료 및 마지막 레코드일 경우 (1) hasNext : false 와 (2) nextAfter, (3)nextCursor 이 null 값으로 들어오는 것 확인
response 일치 확인을 위해 250505 00:45 에 프로토 사이트를 확인했을 때, 프로토 사이트 자체가 페이지네이션이 안되는 것을 확인(스크롤 불가) → (이 기능을 쓰지 않기로 한 걸까요)


### 인기 리뷰
![image](https://github.com/user-attachments/assets/fe0e4922-3d32-4ce6-a832-5ea61874179b)
![image](https://github.com/user-attachments/assets/93a7ff16-1e80-4f26-814f-4074ba040b34)



### Period 체크
*일간, 주간의 경우 테스트 당일 일자가 240505(월) 이므로 동일한 게 맞음
*파워 유저로만 모든 period 확인 후 주간, 월간 생략 (로직이 동일하기 때문에)
*대시보드의 모든 n분 전은 각 유저, 도서, 리뷰의 생성시간이 아닌 대시보드에서 생성된 시각 (프로토 타입과 동일)


1. 파워 유저
![image](https://github.com/user-attachments/assets/69a80af9-2c0d-4b26-96ae-5e634549286e)
<img width="877" alt="image" src="https://github.com/user-attachments/assets/6a80c915-9dc8-4e5f-acb9-e7132ddc5d91" />


2. 인기 도서
<img width="846" alt="image" src="https://github.com/user-attachments/assets/4530f46a-3e0c-4108-99c0-10d0a8c4dfc2" />
1차적으로 도서를 조회할 때 생성일 기준으로 오래된 순서대로 조회하고 있다. = 대시보드에 데이터가 생성될 당시 created_at 에 영향을 주기 때문에 해당 순서가 옳다.


3. 인기 리뷰
<img width="880" alt="image" src="https://github.com/user-attachments/assets/8c2b14f2-8868-403e-90ff-bf98af2697a4" />
*이때 10st가 없는 건 동점자 처리로 인해 못들고 오는 것인데, 이 경우 멘토님과 얘기했던 부분으로 기획적인 면(NextCursor가 rank로 지정되어 `1p의 끝 : rank 10, 2p의 첫 번째 : rank 10` 불가능)입니다.
*추후에 테스트 페이지를 공개할 때는 이런 부분을 보여주기보다 매일매일 데이터를 업데이트(페이지 활용)하여 보이지 않도록 하는 게 좋을 것 같습니다.

<img width="909" alt="image" src="https://github.com/user-attachments/assets/8dd75fe1-943b-4530-8b2b-dbe384213864" />
전체로 했을 때 10stUser 의 리뷰는 example의 리뷰와 비교하여 댓글 수가 차이나기 때문에 10, 11 로 지정


## 💬 공유사항 to 리뷰어
로컬에서 테스트는 완료했습니다! 추후에 AWS 를 통해 배포한 링크에서 오류 생기는 지 확인해보겠습니다.
