### PR TITLE
refactor: comment find

### DIFF
--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/repository/CommentRepository.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/repository/CommentRepository.java
@@ -4,6 +4,7 @@ import com.part3.team07.sb01deokhugamteam07.entity.Comment;
 import com.part3.team07.sb01deokhugamteam07.entity.Review;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -21,5 +22,7 @@ public interface CommentRepository extends JpaRepository<Comment, UUID>, Comment
       LocalDateTime startDateTime,
       LocalDateTime endDateTime);
 
-  List<Comment> findAllByReview(Review review);
+  List<Comment> findAllByReviewAndIsDeletedFalse(Review review);
+
+  Optional<Comment> findByIdAndIsDeletedFalse(UUID id);
 }

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/service/CommentService.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/service/CommentService.java
@@ -113,7 +113,8 @@ public class CommentService {
   @Transactional
   public void hardDelete(UUID commentId, UUID userId) {
     log.debug("hardDelete comment: commentId = {}, userId = {}", commentId, userId);
-    Comment comment = findComment(commentId);
+    Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(CommentNotFoundException::new);
     User user = findUser(userId);
     validateCommentAuthor(comment, user);
     decreaseCommentCountOnHardDelete(comment); //review commentCount 감소

--- a/src/main/java/com/part3/team07/sb01deokhugamteam07/service/CommentService.java
+++ b/src/main/java/com/part3/team07/sb01deokhugamteam07/service/CommentService.java
@@ -84,7 +84,6 @@ public class CommentService {
   public CommentDto find(UUID commentId) {
     log.debug("find comment: commentId = {}", commentId);
     Comment comment = findComment(commentId);
-    isSoftDeleted(comment);
     log.info("find comment complete: commentId = {}", comment.getId());
     return commentMapper.toDto(comment);
   }
@@ -93,7 +92,6 @@ public class CommentService {
   public void softDelete(UUID commentId, UUID userId) {
     log.debug("softDelete comment: commentId = {}", commentId);
     Comment comment = findComment(commentId);
-    isSoftDeleted(comment);
     User user = findUser(userId);
     validateCommentAuthor(comment, user);
     comment.softDelete();
@@ -105,7 +103,7 @@ public class CommentService {
   @Transactional
   public void softDeleteAllByReview(Review review) {
     log.debug("softDelete all comments by review: review = {}", review);
-    List<Comment> comments = commentRepository.findAllByReview(review);
+    List<Comment> comments = commentRepository.findAllByReviewAndIsDeletedFalse(review);
     for (Comment comment : comments) {
       comment.softDelete();
     }
@@ -114,7 +112,7 @@ public class CommentService {
 
   @Transactional
   public void hardDelete(UUID commentId, UUID userId) {
-    log.debug("hardDelete comment: commentId = {}, userId = {}",commentId, userId);
+    log.debug("hardDelete comment: commentId = {}, userId = {}", commentId, userId);
     Comment comment = findComment(commentId);
     User user = findUser(userId);
     validateCommentAuthor(comment, user);
@@ -195,14 +193,8 @@ public class CommentService {
     );
   }
 
-  private void isSoftDeleted(Comment comment) {
-    if (comment.isDeleted()) {
-      throw new CommentNotFoundException();
-    }
-  }
-
   private Comment findComment(UUID commentId) {
-    return commentRepository.findById(commentId)
+    return commentRepository.findByIdAndIsDeletedFalse(commentId)
         .orElseThrow(CommentNotFoundException::new);
   }
 
@@ -224,14 +216,16 @@ public class CommentService {
 
   //commentCount 감소 - 논리삭제
   private void decreaseCommentCountOnSoftDelete(Comment comment) {
-    log.debug("댓글 논리 삭제로 commentCount 감소: reviewId={}, commentId={}", comment.getReview().getId(), comment.getId());
+    log.debug("댓글 논리 삭제로 commentCount 감소: reviewId={}, commentId={}", comment.getReview().getId(),
+        comment.getId());
     reviewRepository.decrementCommentCount(comment.getReview().getId());
   }
 
   //commentCount 감소 - 물리삭제
   private void decreaseCommentCountOnHardDelete(Comment comment) {
     if (!comment.isDeleted()) {
-      log.debug("댓글 물리 삭제로 commentCount 감소: reviewId={}, commentId={}", comment.getReview().getId(), comment.getId());
+      log.debug("댓글 물리 삭제로 commentCount 감소: reviewId={}, commentId={}", comment.getReview().getId(),
+          comment.getId());
       reviewRepository.decrementCommentCount(comment.getReview().getId());
     }
   }


### PR DESCRIPTION
## #️⃣ Issue Number
#196

## 📝 요약(Summary)
댓글 조회 시 일일이 논리삭제 확인하지 않고, db에서 IsDeleted 값이 False인 댓글만 가져오게 변경
논리삭제, 댓글존재X 인 실패 테스트 하나로 통합

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## 💬 공유사항 to 리뷰어
